### PR TITLE
fix(blog): rewrite base url for english posts

### DIFF
--- a/docs/en/blog/posts.data.ts
+++ b/docs/en/blog/posts.data.ts
@@ -37,7 +37,7 @@ export default createContentLoader("en/blog/*.md", {
 
         return {
           title: frontmatter.title,
-          url,
+          url: url.slice('/en'.length), // remove /en for correct url.
           excerpt,
           date: formatDate(frontmatter.date),
           author: frontmatter.author,


### PR DESCRIPTION
In production environment. Open the any blog under the [Blogs](https://tessera-ui.github.io/blog/), will 404 page not found. This PR remove the `/en` of url in english content loader. To keep the rewrite rules working well.